### PR TITLE
patch: reworked sacred to use --local configs

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,0 +1,58 @@
+name: Quality Gate
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+  CARGO_INCREMENTAL: 0
+  RUST_BACKTRACE: short
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v3
+      - name: Install Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          default: true
+      - uses: Swatinem/rust-cache@v1
+      - name: Install Audit
+        run: cargo install cargo-audit
+      - name: Run Audit
+        run: cargo audit
+
+  lint:
+    name: lint-and-format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          default: true
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v1
+      - name: Test Format
+        run: cargo fmt -- --check
+      - run: cargo clippy --tests --all-features --all-targets -- -D clippy::all
+
+  cargo-doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: run cargo doc
+        run: RUSTDOCFLAGS="-D warnings" cargo doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "variant"
-version = "0.1.0"
-edition = "2021"
+version = "0.1.1"
+edition = "2024"
 authors = ["Osoro Bironga <fanosoro@gmail.com>"]
-description = "A command line tool to help you switch git profiles on the fly"
+description = "A command line tool to help you switch git profiles seamlessly"
 
 [dependencies]
-anyhow = "1.0.79"
-clap = { version = "4.4.8", features = ["derive"] }
-home = "0.5.9"
-inquire = "0.6.2"
-serde = { version = "1.0.195", features = ["derive"] }
-serde_json = "1.0.111"
-thiserror = "1.0.56"
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+home = "0.5"
+inquire = "0.9"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ This tool addresses the challenge of managing multiple Git profiles, such as wor
 
 `variant` assumes that you have already have [git](https://git-scm.com/) installed and configured. Also the `ssh-add` command is expected to be available in your PATH, [this is what it does](https://superuser.com/questions/360686/what-exactly-does-ssh-add-do).
 
+### Installation with `cargo`
+
+If you already have cargo installed in your system, use these steps.
+
+```sh
+ cargo install --git https://github.com/muse254/variant.git@main
+```
+
 ## Usage
 
 It assumes a directory structure that looks like this for the git accounts to be managed, `foo` and `bar`:
@@ -33,7 +41,7 @@ git server to ensure that changes effectively took place.
 When I create a new repository, I can specify which account to use:
 
 ```bash
-cd my-awesome-project # We navigate to out project directory
+cd my-awesome-project # We navigate to the project directory
 variant var -n foo # We specify which account to use, assuming variant is in PATH
 ```
 
@@ -44,6 +52,8 @@ you can use the `--sacred` flag:
 cd my-awesome-project
 variant var -n foo --sacred
 ```
+
+This will tie the project to the specified profile and use local git configuration.
 
 We can also query for information about the profile configured:
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,34 +5,52 @@ use std::{io, path::Path, process::Command};
 use anyhow::Result;
 
 use crate::errors::VariantError;
+use crate::plugins::persist::VariantConfig;
 use crate::plugins::{KeyPair, Metadata, Persist, Variant};
 
 /// whoami returns the git profile information for the current configuration.
 pub fn whoami(verbose: bool) -> Result<Vec<u8>, VariantError> {
-    let data = Command::new("git")
-        .args(["config", "--global", "--list"])
-        .output()?;
-
-    if !data.status.success() {
-        return Err(VariantError::Shell(
-            String::from_utf8_lossy(&data.stdout).into(),
-        ));
-    }
+    let is_repo_cached = || -> bool {
+        if let Ok(Some(remote_url)) = get_git_remote_url()
+            && let Ok(project_cache) = VariantConfig::init()
+        {
+            return project_cache.get_project_profile(&remote_url).is_ok();
+        }
+        false
+    };
 
     if verbose {
+        let data = Command::new("git").args(["config", "--list"]).output()?;
+
+        if !data.status.success() {
+            return Err(VariantError::Shell(
+                String::from_utf8_lossy(&data.stdout).into(),
+            ));
+        }
+
         return Ok(data.stdout);
     }
 
-    // Only keeping the lines we care about.
-    const KEYS: [&[u8]; 3] = [b"user.name", b"user.email", b"user.signingkey"];
+    const KEYS: [&str; 3] = ["user.name", "user.email", "user.signingkey"];
+    let use_local = is_repo_cached();
+    let config_flag = if use_local { "--local" } else { "--global" };
 
     let mut truncated = Vec::new();
-    for line in data.stdout.split(|&c| c == b'\n') {
-        for key in KEYS.iter() {
-            if line.starts_with(key) {
+    let mut first = true;
+    for key in KEYS.iter() {
+        let output = Command::new("git")
+            .args(["config", config_flag, "--get", key])
+            .output()?;
+
+        if output.status.success() && !output.stdout.is_empty() {
+            if !first {
                 truncated.extend_from_slice(b"\n");
-                truncated.extend_from_slice(line);
             }
+            truncated.extend_from_slice(key.as_bytes());
+            truncated.extend_from_slice(b"=");
+            let value = output.stdout.strip_suffix(b"\n").unwrap_or(&output.stdout);
+            truncated.extend_from_slice(value);
+            first = false;
         }
     }
 
@@ -70,8 +88,26 @@ pub fn variants() -> Result<Vec<Variant>, VariantError> {
     Ok(variants)
 }
 
+pub fn get_git_remote_url() -> Result<Option<String>, VariantError> {
+    let output = Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .output()?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if url.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(url))
+    }
+}
+
 /// Sets the git profile variant. If sacred is true, then only the local config
 /// will be changed and the global config remains untouched; the inverse is true otherwise.
+/// When sacred is true, the project will be cached and tied to this profile.
 /// The name must be the name of the profile to use. e.g. `foo` or `bar` depending on the
 /// folder the config is in.
 ///
@@ -122,11 +158,22 @@ pub fn set_variant<Cache: Persist>(
     let metadata = match cache.read(name.clone())? {
         Some(metadata) => metadata,
         None => {
-            let data = provider(name)?;
+            let data = provider(name.clone())?;
             cache.write(data.clone())?;
             data
         }
     };
+
+    if let Some(remote_url) = get_git_remote_url()?
+        && sacred
+        && let Ok(project_cache) = VariantConfig::init()
+    {
+        let _ = project_cache.cache_project(remote_url.clone(), name.clone());
+    } else if sacred {
+        return Err(VariantError::System(
+            "Cannot use --sacred flag: not in a git repository with a remote origin.".into(),
+        ));
+    }
 
     for pair in [
         ("user.name", metadata.name),
@@ -151,7 +198,6 @@ pub fn set_variant<Cache: Persist>(
         }
     }
 
-    // log changes
     println!("{}\n", String::from_utf8_lossy(&whoami(false)?));
 
     Ok(())

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -203,6 +203,87 @@ pub fn set_variant<Cache: Persist>(
     Ok(())
 }
 
+/// Switches SSH keys to the specified profile without changing git config.
+pub fn switch_ssh_keys(profile_name: String) -> Result<(), VariantError> {
+    let variant = variants()?
+        .into_iter()
+        .find(|v| v.name == profile_name)
+        .ok_or_else(|| VariantError::System("cannot find variant".into()))?;
+
+    let clear_identities = Command::new("ssh-add")
+        .arg("-D")
+        .stdout(io::stdout())
+        .output()
+        .map_err(|e| VariantError::Shell(e.to_string()))?;
+
+    if !clear_identities.status.success() {
+        return Err(VariantError::Shell(
+            String::from_utf8_lossy(&clear_identities.stdout).into(),
+        ));
+    }
+
+    let register_key = Command::new("ssh-add")
+        .arg(variant.keys.1.to_str().expect("must be valid utf-8"))
+        .stderr(io::stderr())
+        .stdout(io::stdout())
+        .output()
+        .map_err(|e| VariantError::Shell(e.to_string()))?;
+
+    if !register_key.status.success() {
+        return Err(VariantError::Shell(
+            String::from_utf8_lossy(&register_key.stdout).into(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Gets the currently loaded SSH keys by checking ssh-add -l output.
+/// Returns the profile name if a matching key is found, None otherwise.
+pub fn get_current_ssh_profile() -> Result<Option<String>, VariantError> {
+    let output = Command::new("ssh-add")
+        .arg("-l")
+        .output()
+        .map_err(|e| VariantError::Shell(e.to_string()))?;
+
+    if !output.status.success() || output.stdout.is_empty() {
+        return Ok(None);
+    }
+
+    let loaded_fingerprints = String::from_utf8_lossy(&output.stdout);
+    let all_variants = variants()?;
+
+    for variant in all_variants {
+        let key_fingerprint_output = Command::new("ssh-keygen")
+            .args([
+                "-E",
+                "md5",
+                "-lf",
+                variant.keys.1.to_str().expect("must be valid utf-8"),
+            ])
+            .output()
+            .map_err(|e| VariantError::Shell(e.to_string()))?;
+
+        if key_fingerprint_output.status.success() {
+            let fingerprint_line = String::from_utf8_lossy(&key_fingerprint_output.stdout);
+            let fingerprint = fingerprint_line
+                .split_whitespace()
+                .nth(1)
+                .unwrap_or("")
+                .trim()
+                .strip_prefix("MD5:")
+                .unwrap_or("")
+                .trim();
+
+            if !fingerprint.is_empty() && loaded_fingerprints.contains(fingerprint) {
+                return Ok(Some(variant.name));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
 /// keys returns the public key and private key pair, respectively.
 fn keys(path: &Path) -> Result<KeyPair, VariantError> {
     // the algorithm is rudimentary, works for now and there's no need to over-engineer it:

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,9 @@ use clap::Parser;
 mod api;
 mod errors;
 mod plugins;
-use api::{get_git_remote_url, set_variant, variants, whoami};
+use api::{
+    get_current_ssh_profile, get_git_remote_url, set_variant, switch_ssh_keys, variants, whoami,
+};
 use errors::VariantError;
 use plugins::{Persist, persist::VariantConfig, prompt::input_prompt};
 
@@ -182,14 +184,62 @@ fn main() -> ExitCode {
                 }
             }
 
+            let original_ssh_profile = if git_command == "push" {
+                get_current_ssh_profile().ok().flatten()
+            } else {
+                None
+            };
+
+            let target_profile = if git_command == "push" {
+                let project_cache = VariantConfig::init().ok();
+                if let Some(remote_url) = get_git_remote_url().ok().flatten() {
+                    if let Some(cache) = &project_cache {
+                        if let Ok(Some(cached_profile)) = cache.get_project_profile(&remote_url) {
+                            Some(cached_profile)
+                        } else if let Ok(Some(current_profile)) = get_current_profile_username() {
+                            Some(current_profile)
+                        } else {
+                            None
+                        }
+                    } else if let Ok(Some(current_profile)) = get_current_profile_username() {
+                        Some(current_profile)
+                    } else {
+                        None
+                    }
+                } else if let Ok(Some(current_profile)) = get_current_profile_username() {
+                    Some(current_profile)
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
+            if let Some(profile) = &target_profile
+                && original_ssh_profile.as_ref() != Some(profile)
+                && let Err(e) = switch_ssh_keys(profile.clone())
+            {
+                eprintln!("Warning: Failed to switch SSH keys: {}", e);
+            }
+
             let status = Command::new("git").args(&args).status();
-            match status {
+            let exit_code = match status {
                 Ok(s) => ExitCode::from(s.code().unwrap_or(1) as u8),
                 Err(e) => {
                     eprintln!("Failed to execute git: {}", e);
                     ExitCode::FAILURE
                 }
+            };
+
+            if git_command == "push"
+                && let Some(original) = &original_ssh_profile
+                && target_profile.as_ref() != Some(original)
+                && let Err(e) = switch_ssh_keys(original.clone())
+            {
+                eprintln!("Warning: Failed to restore SSH keys: {}", e);
             }
+
+            exit_code
         }
 
         Commands::Version => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,13 @@
+use std::process::{Command, ExitCode};
+
 use clap::Parser;
 
 mod api;
 mod errors;
 mod plugins;
-use api::{set_variant, variants, whoami};
-use plugins::{persist::VariantConfig, prompt::input_prompt};
+use api::{get_git_remote_url, set_variant, variants, whoami};
+use errors::VariantError;
+use plugins::{Persist, persist::VariantConfig, prompt::input_prompt};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
@@ -17,7 +20,7 @@ enum Commands {
         #[arg(short, long)]
         name: String,
         /// Indicates that only the local config will be changed and the global config
-        /// remains untouched.
+        /// remains untouched. The project will be tied to this profile.
         #[arg(short, long, default_value_t = false)]
         sacred: bool,
     },
@@ -31,16 +34,88 @@ enum Commands {
         #[arg(short, long, default_value_t = false)]
         verbose: bool,
     },
+
+    #[command(about = "Wrapper around git commands. Validates profile is set before commits.")]
+    Git {
+        /// Git command and arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    #[command(about = "Prints the version of the application.")]
+    Version,
 }
 
-fn main() {
+fn check_profile_set() -> Result<bool, VariantError> {
+    let output = Command::new("git")
+        .args(["config", "--get", "user.email"])
+        .output()?;
+
+    Ok(output.status.success() && !output.stdout.is_empty())
+}
+
+fn get_current_profile_username() -> Result<Option<String>, VariantError> {
+    let name_output = Command::new("git")
+        .args(["config", "--get", "user.name"])
+        .output()?;
+
+    let email_output = Command::new("git")
+        .args(["config", "--get", "user.email"])
+        .output()?;
+
+    if !name_output.status.success()
+        || name_output.stdout.is_empty()
+        || !email_output.status.success()
+        || email_output.stdout.is_empty()
+    {
+        return Ok(None);
+    }
+
+    let name = String::from_utf8_lossy(&name_output.stdout)
+        .trim()
+        .to_string();
+    let email = String::from_utf8_lossy(&email_output.stdout)
+        .trim()
+        .to_string();
+
+    let project_cache = VariantConfig::init()?;
+    let all_profiles = project_cache.read_all()?;
+
+    for profile in all_profiles {
+        if profile.name == name && profile.email == email {
+            return Ok(Some(profile.username));
+        }
+    }
+
+    Ok(None)
+}
+
+fn check_sacred_association() -> Result<(), VariantError> {
+    if let Some(remote_url) = get_git_remote_url()? {
+        let project_cache = VariantConfig::init()?;
+        if let Some(cached_profile) = project_cache.get_project_profile(&remote_url)?
+            && let Some(current_profile) = get_current_profile_username()?
+            && current_profile != cached_profile
+        {
+            return Err(VariantError::System(format!(
+                "This repository is linked to profile '{}', but current profile is '{}'. Please run 'variant var -n {} --sacred' first.",
+                cached_profile, current_profile, cached_profile
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn main() -> ExitCode {
     match Commands::parse() {
         Commands::Whoami { verbose } => match whoami(verbose) {
             Ok(data) => {
                 println!("{}", String::from_utf8_lossy(&data));
+                ExitCode::SUCCESS
             }
             Err(data) => {
                 eprintln!("{}", data);
+                ExitCode::FAILURE
             }
         },
 
@@ -49,9 +124,11 @@ fn main() {
                 for variant in variants {
                     println!("{}", variant.name);
                 }
+                ExitCode::SUCCESS
             }
             Err(data) => {
                 eprintln!("{}", data);
+                ExitCode::FAILURE
             }
         },
 
@@ -62,11 +139,62 @@ fn main() {
             match set_variant(name, persistance, &input_prompt, sacred) {
                 Ok(_) => {
                     println!("Successfully set variant.");
+                    ExitCode::SUCCESS
                 }
                 Err(data) => {
                     eprintln!("{}", data);
+                    ExitCode::FAILURE
                 }
             }
+        }
+
+        Commands::Git { args } => {
+            if args.is_empty() {
+                let status = Command::new("git").status();
+                return match status {
+                    Ok(s) => ExitCode::from(s.code().unwrap_or(1) as u8),
+                    Err(e) => {
+                        eprintln!("Failed to execute git: {}", e);
+                        ExitCode::FAILURE
+                    }
+                };
+            }
+
+            let git_command = &args[0];
+            if matches!(git_command.as_str(), "commit" | "push" | "add") {
+                match check_profile_set() {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        eprintln!(
+                            "Error: No git profile set. Please run 'variant var -n <profile>' first."
+                        );
+                        return ExitCode::FAILURE;
+                    }
+                    Err(e) => {
+                        eprintln!("Error checking git profile: {}", e);
+                        return ExitCode::FAILURE;
+                    }
+                }
+
+                if let Err(e) = check_sacred_association() {
+                    eprintln!("{}", e);
+                    return ExitCode::FAILURE;
+                }
+            }
+
+            let status = Command::new("git").args(&args).status();
+            match status {
+                Ok(s) => ExitCode::from(s.code().unwrap_or(1) as u8),
+                Err(e) => {
+                    eprintln!("Failed to execute git: {}", e);
+                    ExitCode::FAILURE
+                }
+            }
+        }
+
+        Commands::Version => {
+            println!("{}", env!("CARGO_PKG_VERSION"));
+            ExitCode::SUCCESS
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,19 @@ fn check_sacred_association() -> Result<(), VariantError> {
     Ok(())
 }
 
+fn get_target_profile_for_push() -> Option<String> {
+    let project_cache = VariantConfig::init().ok();
+
+    if let Some(remote_url) = get_git_remote_url().ok().flatten()
+        && let Some(cache) = &project_cache
+        && let Ok(Some(cached_profile)) = cache.get_project_profile(&remote_url)
+    {
+        return Some(cached_profile);
+    }
+
+    get_current_profile_username().ok().flatten()
+}
+
 fn main() -> ExitCode {
     match Commands::parse() {
         Commands::Whoami { verbose } => match whoami(verbose) {
@@ -191,26 +204,7 @@ fn main() -> ExitCode {
             };
 
             let target_profile = if git_command == "push" {
-                let project_cache = VariantConfig::init().ok();
-                if let Some(remote_url) = get_git_remote_url().ok().flatten() {
-                    if let Some(cache) = &project_cache {
-                        if let Ok(Some(cached_profile)) = cache.get_project_profile(&remote_url) {
-                            Some(cached_profile)
-                        } else if let Ok(Some(current_profile)) = get_current_profile_username() {
-                            Some(current_profile)
-                        } else {
-                            None
-                        }
-                    } else if let Ok(Some(current_profile)) = get_current_profile_username() {
-                        Some(current_profile)
-                    } else {
-                        None
-                    }
-                } else if let Ok(Some(current_profile)) = get_current_profile_username() {
-                    Some(current_profile)
-                } else {
-                    None
-                }
+                get_target_profile_for_push()
             } else {
                 None
             };

--- a/src/plugins/persist.rs
+++ b/src/plugins/persist.rs
@@ -1,8 +1,23 @@
 use std::{fs::OpenOptions, path::PathBuf};
 
-use crate::errors::VariantError;
+use serde::{Deserialize, Serialize};
 
 use super::{Metadata, Persist};
+use crate::errors::VariantError;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct ProjectMapping {
+    remote_url: String,
+    profile_username: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+struct CacheData {
+    #[serde(default)]
+    profiles: Vec<Metadata>,
+    #[serde(default)]
+    projects: Vec<ProjectMapping>,
+}
 
 /// Reads and writes to the local cache file to provide persistent storage.
 pub struct VariantConfig {
@@ -17,59 +32,101 @@ impl VariantConfig {
             .ok_or_else(|| VariantError::IO("cannot find home directory".into()))?
             .join(VARIANT_FILE);
 
-        // making sure the file exists, if not create it
-        let _ = OpenOptions::new()
+        OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(false)
             .open(&variant_file)?;
 
         Ok(Self {
             write_path: variant_file,
         })
     }
+
+    pub fn cache_project(
+        &self,
+        remote_url: String,
+        profile_username: String,
+    ) -> Result<(), VariantError> {
+        let mut data = self.read_cache()?;
+
+        if let Some(existing) = data
+            .projects
+            .iter_mut()
+            .find(|p| p.remote_url == remote_url)
+        {
+            existing.profile_username = profile_username;
+        } else {
+            data.projects.push(ProjectMapping {
+                remote_url,
+                profile_username,
+            });
+        }
+
+        self.write_cache(&data)
+    }
+
+    pub fn get_project_profile(&self, remote_url: &str) -> Result<Option<String>, VariantError> {
+        let data = self.read_cache()?;
+        Ok(data
+            .projects
+            .iter()
+            .find(|p| p.remote_url == remote_url)
+            .map(|p| p.profile_username.clone()))
+    }
+
+    fn read_cache(&self) -> Result<CacheData, VariantError> {
+        let content = std::fs::read_to_string(&self.write_path)?;
+        match serde_json::from_str::<CacheData>(&content) {
+            Ok(data) => Ok(data),
+            Err(e) => {
+                if e.is_eof() {
+                    Ok(CacheData::default())
+                } else {
+                    let profiles: Result<Vec<Metadata>, _> = serde_json::from_str(&content);
+                    match profiles {
+                        Ok(profiles) => Ok(CacheData {
+                            profiles,
+                            projects: Vec::new(),
+                        }),
+                        Err(_) => Ok(CacheData::default()),
+                    }
+                }
+            }
+        }
+    }
+
+    fn write_cache(&self, data: &CacheData) -> Result<(), VariantError> {
+        serde_json::to_writer(OpenOptions::new().write(true).open(&self.write_path)?, data)
+            .map_err(|e| e.into())
+    }
 }
 
 impl Persist for VariantConfig {
     fn write(&self, metadata: Metadata) -> Result<(), VariantError> {
-        let write_ = |to_file| -> Result<(), VariantError> {
-            serde_json::to_writer(
-                OpenOptions::new().write(true).open(&self.write_path)?,
-                to_file,
-            )
-            .map_err(|e| e.into())
-        };
+        let mut data = self.read_cache()?;
 
-        let mut data = self.read_all()?;
-        for m in &mut data {
-            if m.username == metadata.username {
-                m.username = metadata.username;
-                m.email = metadata.email;
-
-                write_(&data)?;
-                return Ok(());
-            }
+        if let Some(existing) = data
+            .profiles
+            .iter_mut()
+            .find(|m| m.username == metadata.username)
+        {
+            existing.name = metadata.name;
+            existing.email = metadata.email;
+        } else {
+            data.profiles.push(metadata);
         }
 
-        data.push(metadata);
-        write_(&data)
+        self.write_cache(&data)
     }
 
     fn read(&self, username: String) -> Result<Option<Metadata>, VariantError> {
-        Ok(self
-            .read_all()?
-            .into_iter()
-            .find(|m| m.username == username))
+        let data = self.read_cache()?;
+        Ok(data.profiles.into_iter().find(|m| m.username == username))
     }
 
     fn read_all(&self) -> Result<Vec<Metadata>, VariantError> {
-        match serde_json::from_str::<Vec<Metadata>>(&std::fs::read_to_string(&self.write_path)?) {
-            Ok(data) => Ok(data),
-            Err(e) => {
-                if e.is_eof() {
-                    return Ok(Vec::new());
-                }
-                Err(e.into())
-            }
-        }
+        let data = self.read_cache()?;
+        Ok(data.profiles)
     }
 }

--- a/src/plugins/persist.rs
+++ b/src/plugins/persist.rs
@@ -78,21 +78,21 @@ impl VariantConfig {
     fn read_cache(&self) -> Result<CacheData, VariantError> {
         let content = std::fs::read_to_string(&self.write_path)?;
         match serde_json::from_str::<CacheData>(&content) {
-            Ok(data) => Ok(data),
-            Err(e) => {
-                if e.is_eof() {
-                    Ok(CacheData::default())
-                } else {
-                    let profiles: Result<Vec<Metadata>, _> = serde_json::from_str(&content);
-                    match profiles {
-                        Ok(profiles) => Ok(CacheData {
-                            profiles,
-                            projects: Vec::new(),
-                        }),
-                        Err(_) => Ok(CacheData::default()),
-                    }
+            Ok(data) => return Ok(data),
+            Err(err) => {
+                if err.is_eof() {
+                    return Ok(CacheData::default());
                 }
             }
+        };
+
+        let profiles: Result<Vec<Metadata>, _> = serde_json::from_str(&content);
+        match profiles {
+            Ok(profiles) => Ok(CacheData {
+                profiles,
+                projects: Vec::new(),
+            }),
+            Err(_) => Ok(CacheData::default()),
         }
     }
 

--- a/src/plugins/prompt.rs
+++ b/src/plugins/prompt.rs
@@ -9,7 +9,7 @@ pub fn input_prompt(username: String) -> Result<Metadata, VariantError> {
             Ok(n) => n,
             Err(e) => return Err(VariantError::IO(e.to_string())),
         },
-        email: match Text::new("git metadata to set in config?").prompt() {
+        email: match Text::new("git metadata email to set in config?").prompt() {
             Ok(e) => e,
             Err(e) => return Err(VariantError::IO(e.to_string())),
         },


### PR DESCRIPTION
We are wrapping the `git` command to allow for automatic switching of ssh configs, you use `--sacred ` once on a repo and you forget about ever having to manage profiles for it from `git commit` to `git push`; it just works